### PR TITLE
Changed java SDK version used, therefore DRIVING transport mode is su…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ DRIVING_FERRY
 PUBLIC_TRANSPORT
 WALKING_FERRY
 CYCLING_FERRY
+DRIVING
 ```
 
 Maximum travel time is currently 7200 (2 hours).

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.traveltime</groupId>
             <artifactId>traveltime-sdk-java</artifactId>
-            <version>1.1.10</version>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
traveltime-sdk-java 1.2.4 version is used instead of 1.1.10. That makes DRIVING mode supported for bench marking.