### PR TITLE
Packaging project with its dependencies in a .jar and then executing …

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:experimental
-FROM maven:3-openjdk-11
+FROM maven:3-openjdk-11 AS build
+COPY src /usr/src/app/src
+COPY pom.xml /usr/src/app
+RUN mvn -f /usr/src/app/pom.xml package shade:shade
 
-ADD src/ /src
-ADD pom.xml /
-RUN --mount=type=cache,target=/root/.m2 mvn install
 
-ADD docker/entrypoint.sh /
-RUN chmod +x ./entrypoint.sh
-ENTRYPOINT /entrypoint.sh
+FROM gcr.io/distroless/java
+COPY --from=build /usr/src/app/target/traveltime-benchmarks-1.0-SNAPSHOT.jar /usr/app/traveltime-benchmarks-1.0-SNAPSHOT.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/usr/app/traveltime-benchmarks-1.0-SNAPSHOT.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,4 @@ RUN mvn -f /usr/src/app/pom.xml package shade:shade
 
 FROM gcr.io/distroless/java
 COPY --from=build /usr/src/app/target/traveltime-benchmarks-1.0-SNAPSHOT.jar /usr/app/traveltime-benchmarks-1.0-SNAPSHOT.jar
-EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/usr/app/traveltime-benchmarks-1.0-SNAPSHOT.jar"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -x
-
-mvn install exec:exec

--- a/pom.xml
+++ b/pom.xml
@@ -36,24 +36,15 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>1.34</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.4.1</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <executable>${JAVA_HOME}/bin/java</executable>
-                    <arguments>
-                        <argument>-ea</argument>
-                        <argument>-classpath</argument>
-                        <classpath />
-                        <argument>com.traveltime.benchmarks.TimeFilterFastBenchmark</argument>
-                    </arguments>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -61,6 +52,26 @@
                     <source>11</source>
                     <target>11</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.traveltime.benchmarks.TimeFilterFastBenchmark</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
…it. This solves the problem - dependencies being downloaded everytime bench marker is executed.