### PR TITLE
Fixed thresholds not working

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -21,9 +21,19 @@ export function deleteTimeMapMetrics (data) {
   delete data.metrics.http_req_connecting
   delete data.metrics.http_req_failed
   delete data.metrics.http_req_tls_handshaking
+}
+
+export function timeMapReport (data) {
+  data.metrics.http_req_sending =
+               data.metrics['http_req_sending{scenario:mainScenario}']
   delete data.metrics['http_req_sending{scenario:mainScenario}']
+  data.metrics.http_req_duration =
+                 data.metrics['http_req_duration{scenario:mainScenario}']
   delete data.metrics['http_req_duration{scenario:mainScenario}']
+  data.metrics.http_req_receiving =
+                data.metrics['http_req_receiving{scenario:mainScenario}']
   delete data.metrics['http_req_receiving{scenario:mainScenario}']
+  return data
 }
 
 export const destinations = (__ENV.DESTINATIONS || '50, 100, 150')

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -12,7 +12,8 @@ import {
   summaryTrendStats,
   timeMapScenarios as scenarios,
   setThresholdsForScenarios,
-  deleteTimeMapMetrics
+  deleteTimeMapMetrics,
+  timeMapReport
 } from './common.js'
 
 export const options = {
@@ -56,6 +57,8 @@ export default function () {
 
 export function handleSummary (data) {
   deleteTimeMapMetrics(data)
+
+  data = timeMapReport(data)
 
   return {
     stdout: textSummary(data, {

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -12,7 +12,8 @@ import {
   timeMapScenarios as scenarios,
   setThresholdsForScenarios,
   summaryTrendStats,
-  deleteTimeMapMetrics
+  deleteTimeMapMetrics,
+  timeMapReport
 } from './common.js'
 
 export const options = {
@@ -53,6 +54,8 @@ export default function () {
 
 export function handleSummary (data) {
   deleteTimeMapMetrics(data)
+
+  data = timeMapReport(data)
 
   return {
     stdout: textSummary(data, {


### PR DESCRIPTION
After recent addition of time-map and time-filter endpoints, there was a problem where we could not see whether thresholds passed or not in time-map and time-map-fast (because I was deleting the result with the threshold). Problem is now fixed.