### PR TITLE
Fix for `walking+ferry` + `cycling+ferry`

### DIFF
--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -103,9 +103,9 @@ function transportationType (transportation) {
     case 'driving+ferry':
       return 'DRIVING_AND_FERRY'
     case 'walking+ferry':
-      return 'WALKING_FERRY'
+      return 'WALKING_AND_FERRY'
     case 'cycling+ferry':
-      return 'CYCLING_FERRY'
+      return 'CYCLING_AND_FERRY'
     case 'pt':
       return 'PUBLIC_TRANSPORT'
     default:


### PR DESCRIPTION
If yuo would look at: 
https://github.com/traveltime-dev/traveltime-benchmarks/blob/master/proto/TimeFilterFastRequest.proto#L14, 
you would see that we have a bug.