### PR TITLE
Generating coords before running bencmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many requests with random locations to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 
@@ -40,6 +41,7 @@ docker run
     -e LEVEL_OF_DETAILS=2 // optional
     -e RPM=200 // optional
     -e ARRIVAL_TIME_PERIOD='weekday_morning' //optional
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many requests with random locations to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 
@@ -54,8 +56,9 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
-    -e DESTINATIONS="100,150,200" // optional
+    -e DESTINATIONS=50 // optional
     -e RANGE=600 //optional
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter.js
 ```
 
@@ -69,6 +72,7 @@ docker run
     -e COUNTRY=gb //optional
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/routes.js
 ```
 
@@ -78,13 +82,14 @@ docker run
 docker run 
     -e APP_ID={APP_ID}
     -e API_KEY={API_KEY}
-    -e DESTINATIONS="1000,5000,10000,25000,100000" // optional
+    -e DESTINATIONS=50 // optional
     -e MANY_TO_ONE // optional
     -e HOST=proto.api.traveltimeapp.com // optional
     -e TRANSPORTATION=driving+ferry // optional
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e COUNTRY=uk // optional, but mandatory if COORDINATES are specified
     -e TRAVEL_TIME=7200 // optional
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter-proto.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
+    -e RPM=60 // optional
+    -e TEST_DURATION=3 //optional, benchmark duration in minutes (not including warmup)
     -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
@@ -39,7 +41,8 @@ docker run
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
     -e LEVEL_OF_DETAILS=2 // optional
-    -e RPM=200 // optional
+    -e RPM=60 // optional
+    -e TEST_DURATION=3 //optional, benchmark duration in minutes (not including warmup)
     -e ARRIVAL_TIME_PERIOD='weekday_morning' //optional
     -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
@@ -58,6 +61,8 @@ docker run
     -e TRAVEL_TIME=7200 //optional
     -e DESTINATIONS=50 // optional
     -e RANGE=600 //optional
+    -e RPM=60 // optional
+    -e TEST_DURATION=3 //optional, benchmark duration in minutes (not including warmup)
     -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter.js
 ```
@@ -72,6 +77,8 @@ docker run
     -e COUNTRY=gb //optional
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
+    -e RPM=60 // optional
+    -e TEST_DURATION=3 //optional, benchmark duration in minutes (not including warmup)
     -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/routes.js
 ```
@@ -88,6 +95,8 @@ docker run
     -e TRANSPORTATION=driving+ferry // optional
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e COUNTRY=uk // optional, but mandatory if COORDINATES are specified
+    -e RPM=60 // optional
+    -e TEST_DURATION=3 //optional, benchmark duration in minutes (not including warmup)
     -e TRAVEL_TIME=7200 // optional
     -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter-proto.js

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many requests with random locations to generate
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 
@@ -41,7 +41,7 @@ docker run
     -e LEVEL_OF_DETAILS=2 // optional
     -e RPM=200 // optional
     -e ARRIVAL_TIME_PERIOD='weekday_morning' //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many requests with random locations to generate
+    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,3 +213,102 @@ running (3m05.0s), 0000/0100 VUs, 180 complete and 0 interrupted iterations
 mainScenario ✓ [======================================] 0000/0100 VUs  3m0s  1.00 iters/s
 ```
 
+### Benchmark results:
+
+---
+
+#### t2.medium (2 vCPUs, 2.3 GHz, 4 GiB RAM, Low to Moderate network speed)
+
+#### 5000 destinations
+
+```
+  checks.................: 100.00% ✓ 1628   ✗ 0  
+  data_received..........: 44 MB   136 kB/s
+  data_sent..............: 82 MB   257 kB/s
+✓ http_req_duration......: avg=170.71ms min=129.8ms  max=243.75ms p(90)=195.18ms p(95)=207.66ms
+✓ http_req_receiving.....: avg=3.08ms   min=75.76µs  max=70.64ms  p(95)=20.17ms 
+✓ http_req_sending.......: avg=702.06µs min=163.23µs max=27.65ms  p(90)=433.48µs p(95)=4.14ms  
+```
+
+#### 10000 destinations
+```
+  checks................: 100.00% ✓ 1628   ✗ 0  
+  data_received.........: 44 MB   136 kB/s
+  data_sent.............: 82 MB   257 kB/s
+✓ http_req_duration.....: avg=172.66ms min=138.54ms max=256.05ms p(90)=198.56ms p(95)=210.49ms
+✓ http_req_receiving....: avg=2.72ms   min=98.06µs  max=32.23ms  p(90)=5.94ms   p(95)=19.12ms 
+✓ http_req_sending......: avg=1.19ms   min=144.5µs  max=23.15ms  p(90)=3.51ms   p(95)=6.38ms  
+```
+
+#### 25000 destinations
+
+```
+  checks................: 100.00% ✓ 1628   ✗ 0  
+  data_received.........: 44 MB   136 kB/s
+  data_sent.............: 82 MB   257 kB/s
+✓ http_req_duration.....: avg=194.7ms  min=161.1ms  max=288.05ms p(90)=232.02ms p(95)=242.05ms
+✓ http_req_receiving....: avg=8.17ms   min=152.56µs max=80.11ms  p(90)=23.09ms  p(95)=46.15ms 
+✓ http_req_sending......: avg=15.25ms  min=11.19ms  max=57.39ms  p(90)=21.06ms  p(95)=22.85ms 
+```
+
+#### 100000 destinations
+
+```
+  checks...............: 100.00% ✓ 1628   ✗ 0  
+  data_received........: 44 MB   136 kB/s
+  data_sent............: 82 MB   257 kB/s
+✓ http_req_duration....: avg=234.59ms min=203.12ms max=300.75ms p(90)=257.02ms p(95)=279.58ms
+✓ http_req_receiving...: avg=7.34ms   min=424.64µs max=51.96ms  p(90)=14.41ms  p(95)=24.98ms 
+✓ http_req_sending.....: avg=45.98ms  min=42.91ms  max=63.48ms  p(90)=54.15ms  p(95)=57.37ms 
+```
+
+---
+
+#### m6i.xlarge (4 vCPUs, 3.5 GHz, 16 GiB RAM, Up to 12.5 Gigabit network speed)
+
+#### 5000 destinations
+
+```
+  checks.................: 100.00% ✓ 1756   ✗ 0  
+  data_received..........: 51 MB   157 kB/s
+  data_sent..............: 96 MB   298 kB/s
+✓ http_req_duration......: avg=167.3ms  min=137.71ms max=376.6ms  p(90)=180.37ms p(95)=186.33ms
+✓ http_req_receiving.....: avg=227.48µs min=54.42µs  max=25.04ms  p(90)=128.9µs  p(95)=554.96µs
+✓ http_req_sending.......: avg=161.55µs min=92.66µs  max=548.16µs p(90)=196.87µs p(95)=223.44µs
+```
+
+#### 10000 destinations
+
+```
+
+  checks................: 100.00% ✓ 1756   ✗ 0  
+  data_received.........: 51 MB   157 kB/s
+  data_sent.............: 96 MB   298 kB/s
+✓ http_req_duration.....: avg=167.28ms min=136.7ms  max=286.89ms p(90)=179.34ms p(95)=187.72ms
+✓ http_req_receiving....: avg=1.29ms   min=117.9µs  max=20.42ms  p(90)=1.95ms   p(95)=3.71ms  
+✓ http_req_sending......: avg=188.3µs  min=118.36µs max=3.73ms   p(90)=203.7µs  p(95)=227.62µs
+```
+
+#### 25000 destinations
+
+```
+  checks................: 100.00% ✓ 1756   ✗ 0  
+  data_received.........: 51 MB   157 kB/s
+  data_sent.............: 96 MB   298 kB/s
+✓ http_req_duration.....: avg=191.41ms min=152.33ms max=267.06ms p(90)=217.06ms p(95)=239.51ms
+✓ http_req_receiving....: avg=7.62ms   min=137.34µs max=76.98ms  p(90)=10.53ms  p(95)=44.92ms 
+✓ http_req_sending......: avg=11.92ms  min=11.39ms  max=24.34ms  p(90)=12.12ms  p(95)=12.51ms 
+```
+
+#### 100000 destinations
+
+```
+  checks...............: 100.00% ✓ 1756   ✗ 0  
+  data_received........: 51 MB   157 kB/s
+  data_sent............: 96 MB   298 kB/s
+✓ http_req_duration....: avg=224.92ms min=200.23ms max=336.37ms p(90)=253.82ms p(95)=271.77ms
+✓ http_req_receiving...: avg=6.58ms   min=3.95ms   max=32.25ms  p(90)=9.03ms   p(95)=14.04ms 
+✓ http_req_sending.....: avg=43.76ms  min=42.45ms  max=48.43ms  p(90)=45.24ms  p(95)=47.91ms 
+```
+
+---

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
     -e TRAVEL_TIME=7200 //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
+    -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 
@@ -41,7 +41,7 @@ docker run
     -e LEVEL_OF_DETAILS=2 // optional
     -e RPM=200 // optional
     -e ARRIVAL_TIME_PERIOD='weekday_morning' //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
+    -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-map.js
 ```
 
@@ -58,7 +58,7 @@ docker run
     -e TRAVEL_TIME=7200 //optional
     -e DESTINATIONS=50 // optional
     -e RANGE=600 //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
+    -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter.js
 ```
 
@@ -72,7 +72,7 @@ docker run
     -e COUNTRY=gb //optional
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e TRANSPORTATION='driving+ferry' //optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
+    -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/routes.js
 ```
 
@@ -89,7 +89,7 @@ docker run
     -e COORDINATES=-8,13 // optional, this will overwrite COUNTRY env var
     -e COUNTRY=uk // optional, but mandatory if COORDINATES are specified
     -e TRAVEL_TIME=7200 // optional
-    -e UNIQUE_REQUESTS=1 // optional, this specifies how many unique requests to generate
+    -e UNIQUE_REQUESTS=2 // optional, percentage of requests that should be unique
     -ti igeolise/traveltime-k6-benchmarks:latest k6 run scripts/time-filter-proto.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,38 +181,6 @@ walking+ferry
 3. Build: `xk6 build --with github.com/traveltime-dev/xk6-protobuf@latest  --with github.com/grafana/xk6-output-prometheus-remote@latest`
 4. Run: ` ./k6 run -e APP_ID={APP_ID} -e API_KEY={API_KEY} -e HOST={HOST} scripts/{proto-benchmark-file}.js`
 
-### Benchmark results example:
-
-```
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
-
-     execution: local
-        script: ./scripts/time-filter.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 3000 max VUs, 3m15s max duration (incl. graceful stop):
-              * mainScenario: 1.00 iterations/s for 3m0s (maxVUs: 100-3000, startTime: 5s, gracefulStop: 10s)
-
-     ✓ status is 200
-     ✓ response body is not empty
-
-     █ setup
-
-     checks...............: 100.00% ✓ 360    ✗ 0    
-     data_received........: 1.1 MB  6.2 kB/s
-     data_sent............: 1.0 MB  5.5 kB/s
-   ✓ http_req_duration....: avg=340.49ms min=239.51ms max=619.23ms p(90)=436.24ms p(95)=473.31ms
-   ✓ http_req_receiving...: avg=622.6µs  min=50.53µs  max=2.63ms   p(90)=1.69ms   p(95)=1.94ms  
-   ✓ http_req_sending.....: avg=293.7µs  min=101.74µs max=798.2µs  p(90)=490.6µs  p(95)=527.14µs
-
-running (3m05.0s), 0000/0100 VUs, 180 complete and 0 interrupted iterations
-mainScenario ✓ [======================================] 0000/0100 VUs  3m0s  1.00 iters/s
-```
-
 ### Benchmark results:
 
 ---

--- a/README.md
+++ b/README.md
@@ -172,45 +172,35 @@ walking+ferry
 3. Build: `xk6 build --with github.com/traveltime-dev/xk6-protobuf@latest  --with github.com/grafana/xk6-output-prometheus-remote@latest`
 4. Run: ` ./k6 run -e APP_ID={APP_ID} -e API_KEY={API_KEY} -e HOST={HOST} scripts/{proto-benchmark-file}.js`
 
-### Benchmark results:
+### Benchmark results example:
 
 ```
-t2.medium
-2 vCPUs, 2.3 GHz, 4 GiB RAM, Low to Moderate network speed
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
 
-  checks....................................: 100.00% ✓ 1628   ✗ 0  
-  data_received.............................: 44 MB   136 kB/s
-  data_sent.................................: 82 MB   257 kB/s
-✓ http_req_duration(10000 destinations).....: avg=172.66ms min=138.54ms max=256.05ms p(90)=198.56ms p(95)=210.49ms
-✓ http_req_duration(100000 destinations)....: avg=234.59ms min=203.12ms max=300.75ms p(90)=257.02ms p(95)=279.58ms
-✓ http_req_duration(25000 destinations).....: avg=194.7ms  min=161.1ms  max=288.05ms p(90)=232.02ms p(95)=242.05ms
-✓ http_req_duration(5000 destinations)......: avg=170.71ms min=129.8ms  max=243.75ms p(90)=195.18ms p(95)=207.66ms
-✓ http_req_receiving(10000 destinations)....: avg=2.72ms   min=98.06µs  max=32.23ms  p(90)=5.94ms   p(95)=19.12ms 
-✓ http_req_receiving(100000 destinations)...: avg=7.34ms   min=424.64µs max=51.96ms  p(90)=14.41ms  p(95)=24.98ms 
-✓ http_req_receiving(25000 destinations)....: avg=8.17ms   min=152.56µs max=80.11ms  p(90)=23.09ms  p(95)=46.15ms 
-✓ http_req_receiving(5000 destinations).....: avg=3.08ms   min=75.76µs  max=70.64ms  p(90)=13.7ms   p(95)=20.17ms 
-✓ http_req_sending(10000 destinations)......: avg=1.19ms   min=144.5µs  max=23.15ms  p(90)=3.51ms   p(95)=6.38ms  
-✓ http_req_sending(100000 destinations).....: avg=45.98ms  min=42.91ms  max=63.48ms  p(90)=54.15ms  p(95)=57.37ms 
-✓ http_req_sending(25000 destinations)......: avg=15.25ms  min=11.19ms  max=57.39ms  p(90)=21.06ms  p(95)=22.85ms 
-✓ http_req_sending(5000 destinations).......: avg=702.06µs min=163.23µs max=27.65ms  p(90)=433.48µs p(95)=4.14ms  
+     execution: local
+        script: ./scripts/time-filter.js
+        output: -
 
-m6i.xlarge
-4 vCPUs, 3.5 GHz, 16 GiB RAM, Up to 12.5 Gigabit network speed
+     scenarios: (100.00%) 1 scenario, 3000 max VUs, 3m15s max duration (incl. graceful stop):
+              * mainScenario: 1.00 iterations/s for 3m0s (maxVUs: 100-3000, startTime: 5s, gracefulStop: 10s)
 
-  checks....................................: 100.00% ✓ 1756   ✗ 0  
-  data_received.............................: 51 MB   157 kB/s
-  data_sent.................................: 96 MB   298 kB/s
-✓ http_req_duration(10000 destinations).....: avg=167.28ms min=136.7ms  max=286.89ms p(90)=179.34ms p(95)=187.72ms
-✓ http_req_duration(100000 destinations)....: avg=224.92ms min=200.23ms max=336.37ms p(90)=253.82ms p(95)=271.77ms
-✓ http_req_duration(25000 destinations).....: avg=191.41ms min=152.33ms max=267.06ms p(90)=217.06ms p(95)=239.51ms
-✓ http_req_duration(5000 destinations)......: avg=167.3ms  min=137.71ms max=376.6ms  p(90)=180.37ms p(95)=186.33ms
-✓ http_req_receiving(10000 destinations)....: avg=1.29ms   min=117.9µs  max=20.42ms  p(90)=1.95ms   p(95)=3.71ms  
-✓ http_req_receiving(100000 destinations)...: avg=6.58ms   min=3.95ms   max=32.25ms  p(90)=9.03ms   p(95)=14.04ms 
-✓ http_req_receiving(25000 destinations)....: avg=7.62ms   min=137.34µs max=76.98ms  p(90)=10.53ms  p(95)=44.92ms 
-✓ http_req_receiving(5000 destinations).....: avg=227.48µs min=54.42µs  max=25.04ms  p(90)=128.9µs  p(95)=554.96µs
-✓ http_req_sending(10000 destinations)......: avg=188.3µs  min=118.36µs max=3.73ms   p(90)=203.7µs  p(95)=227.62µs
-✓ http_req_sending(100000 destinations).....: avg=43.76ms  min=42.45ms  max=48.43ms  p(90)=45.24ms  p(95)=47.91ms 
-✓ http_req_sending(25000 destinations)......: avg=11.92ms  min=11.39ms  max=24.34ms  p(90)=12.12ms  p(95)=12.51ms 
-✓ http_req_sending(5000 destinations).......: avg=161.55µs min=92.66µs  max=548.16µs p(90)=196.87µs p(95)=223.44µs
+     ✓ status is 200
+     ✓ response body is not empty
+
+     █ setup
+
+     checks...............: 100.00% ✓ 360    ✗ 0    
+     data_received........: 1.1 MB  6.2 kB/s
+     data_sent............: 1.0 MB  5.5 kB/s
+   ✓ http_req_duration....: avg=340.49ms min=239.51ms max=619.23ms p(90)=436.24ms p(95)=473.31ms
+   ✓ http_req_receiving...: avg=622.6µs  min=50.53µs  max=2.63ms   p(90)=1.69ms   p(95)=1.94ms  
+   ✓ http_req_sending.....: avg=293.7µs  min=101.74µs max=798.2µs  p(90)=490.6µs  p(95)=527.14µs
+
+running (3m05.0s), 0000/0100 VUs, 180 complete and 0 interrupted iterations
+mainScenario ✓ [======================================] 0000/0100 VUs  3m0s  1.00 iters/s
 ```
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -41,25 +41,6 @@ export function oneScenarioReport (data) {
   return data
 }
 
-export const destinations = (__ENV.DESTINATIONS || '50, 100, 150')
-  .split(',')
-  .map((curDestinations) => parseInt(curDestinations))
-
-export const multipleDestinationsScenarios = destinations.reduce((accumulator, currentDestinations) => {
-  accumulator[`sending_${currentDestinations}_destinations`] = {
-    executor: 'constant-arrival-rate',
-    duration: '3m',
-    env: { SCENARIO_DESTINATIONS: currentDestinations.toString() },
-    rate: rpm,
-    timeUnit: '1m',
-    startTime: '5s',
-    gracefulStop: '10s',
-    preAllocatedVUs: 100,
-    maxVUs: 3000
-  }
-  return accumulator
-}, {})
-
 export function deleteTimeFilterMetrics (data) {
   delete data.metrics.http_req_duration
   delete data.metrics.http_req_sending

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -30,13 +30,13 @@ export function deleteOneScenarioMetrics (data) {
 
 export function oneScenarioReport (data) {
   data.metrics.http_req_sending =
-      data.metrics['http_req_sending{scenario:mainScenario}']
+    data.metrics['http_req_sending{scenario:mainScenario}']
   delete data.metrics['http_req_sending{scenario:mainScenario}']
   data.metrics.http_req_duration =
-      data.metrics['http_req_duration{scenario:mainScenario}']
+    data.metrics['http_req_duration{scenario:mainScenario}']
   delete data.metrics['http_req_duration{scenario:mainScenario}']
   data.metrics.http_req_receiving =
-      data.metrics['http_req_receiving{scenario:mainScenario}']
+    data.metrics['http_req_receiving{scenario:mainScenario}']
   delete data.metrics['http_req_receiving{scenario:mainScenario}']
   return data
 }
@@ -78,13 +78,13 @@ export function deleteTimeFilterMetrics (data) {
 
 export function reportPerDestination (data, destinations) {
   data.metrics[`http_req_sending(${destinations} destinations)`] =
-               data.metrics[`http_req_sending{scenario:sending_${destinations}_destinations}`]
+    data.metrics[`http_req_sending{scenario:sending_${destinations}_destinations}`]
   delete data.metrics[`http_req_sending{scenario:sending_${destinations}_destinations}`]
   data.metrics[`http_req_receiving(${destinations} destinations)`] =
-               data.metrics[`http_req_receiving{scenario:sending_${destinations}_destinations}`]
+    data.metrics[`http_req_receiving{scenario:sending_${destinations}_destinations}`]
   delete data.metrics[`http_req_receiving{scenario:sending_${destinations}_destinations}`]
   data.metrics[`http_req_duration(${destinations} destinations)`] =
-               data.metrics[`http_req_duration{scenario:sending_${destinations}_destinations}`]
+    data.metrics[`http_req_duration{scenario:sending_${destinations}_destinations}`]
   delete data.metrics[`http_req_duration{scenario:sending_${destinations}_destinations}`]
   return data
 }
@@ -389,6 +389,10 @@ export const protoCountries = {
 
 function randomInRange (min, max) {
   return Math.random() * (max - min) + min
+}
+
+export function randomIndex (length) {
+  return Math.floor(randomInRange(0, length))
 }
 
 export function generateRandomCoordinate (lat, lng, diff) {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,11 +1,12 @@
 export const summaryTrendStats = ['avg', 'min', 'max', 'p(90)', 'p(95)']
 
 export const rpm = parseInt(__ENV.RPM || '60')
+export const durationInMinutes = 3
 
 export const oneScenario = {
   mainScenario: {
     executor: 'constant-arrival-rate',
-    duration: '3m',
+    duration: durationInMinutes + 'm',
     rate: rpm,
     timeUnit: '1m',
     startTime: '5s',

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,18 +1,21 @@
 export const summaryTrendStats = ['avg', 'min', 'max', 'p(90)', 'p(95)']
 
-export const rpm = parseInt(__ENV.RPM || '60')
+export const rpm = parseInt(__ENV.RPM || '1000')
 export const durationInMinutes = 3
+const warmupDurationInMinutes = 2
 
 export const oneScenario = {
   mainScenario: {
-    executor: 'constant-arrival-rate',
-    duration: durationInMinutes + 'm',
-    rate: rpm,
+    executor: 'ramping-arrival-rate',
+    startRate: 0,
     timeUnit: '1m',
-    startTime: '5s',
-    gracefulStop: '10s',
-    preAllocatedVUs: 100,
-    maxVUs: 3000
+    gracefulStop: '15s',
+    preAllocatedVUs: 10,
+    maxVUs: 300,
+    stages: [
+      { target: rpm, duration: warmupDurationInMinutes + 'm' },
+      { target: rpm, duration: durationInMinutes + 'm' }
+    ]
   }
 }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,7 +1,3 @@
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
-
 export const summaryTrendStats = ['avg', 'min', 'max', 'p(90)', 'p(95)']
 
 export const rpm = parseInt(__ENV.RPM || '60')
@@ -9,17 +5,17 @@ export const rpm = parseInt(__ENV.RPM || '60')
 export const oneScenario = {
   mainScenario: {
     executor: 'constant-arrival-rate',
-    duration: '5s',
+    duration: '3m',
     rate: rpm,
-    timeUnit: '5s',
-    startTime: '1s',
-    gracefulStop: '1s',
+    timeUnit: '1m',
+    startTime: '5s',
+    gracefulStop: '10s',
     preAllocatedVUs: 100,
     maxVUs: 3000
   }
 }
 
-function deleteOneScenarioMetrics (data) {
+export function deleteOneScenarioMetrics (data) {
   delete data.metrics.http_req_blocked
   delete data.metrics['http_req_duration{expected_response:true}']
   delete data.metrics.http_req_waiting
@@ -43,20 +39,6 @@ export function oneScenarioReport (data) {
     data.metrics['http_req_receiving{scenario:mainScenario}']
   delete data.metrics['http_req_receiving{scenario:mainScenario}']
   return data
-}
-
-export function handleSummaryInternal(data){
-  // removing default metrics
-  deleteOneScenarioMetrics(data)
-
-  data = oneScenarioReport(data)
-
-  return {
-    stdout: textSummary(data, {
-      indent: ' ',
-      enableColors: true
-    })
-  }
 }
 
 export function setThresholdsForScenarios (options) {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,7 +1,7 @@
 export const summaryTrendStats = ['avg', 'min', 'max', 'p(90)', 'p(95)']
 
-export const rpm = parseInt(__ENV.RPM || '1000')
-export const durationInMinutes = 3
+export const rpm = parseInt(__ENV.RPM || '60')
+export const durationInMinutes = parseInt(__ENV.TEST_DURATION || '3')
 const warmupDurationInMinutes = 2
 
 export const oneScenario = {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -354,10 +354,6 @@ export function generateRandomCoordinate (lat, lng, diff) {
   }
 }
 
-export function generateRequestBodies (count, generateBodyFn, ...args) {
-  return Array.from({ length: count }, () => generateBodyFn(...args))
-}
-
 export function generateDestinations (numCoordinates, departure, diff) {
   return Array.from({ length: numCoordinates }, () =>
     generateRandomCoordinate(departure.lat, departure.lng, diff)

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -402,6 +402,10 @@ export function generateRandomCoordinate (lat, lng, diff) {
   }
 }
 
+export function generateRequestBodies (count, generateBodyFn, ...args) {
+  return Array.from({ length: count }, () => generateBodyFn(...args))
+}
+
 export function generateDestinations (numCoordinates, departure, diff) {
   return Array.from({ length: numCoordinates }, () =>
     generateRandomCoordinate(departure.lat, departure.lng, diff)

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,3 +1,4 @@
+import { getCurrentStageIndex } from 'https://jslib.k6.io/k6-utils/1.3.0/index.js'
 import {
   textSummary
 } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
@@ -60,10 +61,12 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
+  if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
   check(response, {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
+  }
 }
 
 export function handleSummary (data) {

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -15,7 +15,6 @@ import {
   deleteOneScenarioMetrics,
   oneScenarioReport,
   getCountryCoordinates,
-  generateRequestBodies,
   randomIndex
 } from './common.js'
 
@@ -50,7 +49,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, transportation, countryCoords, dateTime)
+  const requestBodies = generateRequestBodies(uniqueRequests, transportation, countryCoords, dateTime)
   return { url, requestBodies, params }
 }
 
@@ -79,11 +78,7 @@ export function handleSummary (data) {
   }
 }
 
-function generateBody (
-  transportation,
-  countryCoords,
-  dateTime
-) {
+function generateBody (transportation, countryCoords, dateTime) {
   const coordinates = countryCoords
   const diff = 0.01
 
@@ -114,4 +109,8 @@ function generateBody (
     locations: [origin, destination],
     departure_searches: departureSearches
   })
+}
+
+function generateRequestBodies (count, transportation, countryCoords, dateTime) {
+  return Array.from({ length: count }, () => generateBody(transportation, countryCoords, dateTime))
 }

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,6 +1,3 @@
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -12,10 +9,9 @@ import {
   oneScenario as scenarios,
   setThresholdsForScenarios,
   summaryTrendStats,
-  deleteOneScenarioMetrics as deleteRoutesMetrics,
-  oneScenarioReport as routesReport,
   getCountryCoordinates,
   generateRequestBodies,
+  handleSummaryInternal,
   randomIndex
 } from './common.js'
 
@@ -58,8 +54,6 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
-  console.log(response.status)
-
   check(response, {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
@@ -68,16 +62,7 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  // removing default metrics
-  deleteRoutesMetrics(data)
-  data = routesReport(data)
-
-  return {
-    stdout: textSummary(data, {
-      indent: ' ',
-      enableColors: true
-    })
-  }
+  handleSummaryInternal(data)
 }
 
 function generateBody (

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -17,13 +17,6 @@ import {
   getCountryCoordinates,
   generateRequestBodies,
   randomIndex
-  generateRandomCoordinate,
-  oneScenario as scenarios,
-  setThresholdsForScenarios,
-  summaryTrendStats,
-  deleteOneScenarioMetrics as deleteRoutesMetrics,
-  oneScenarioReport as routesReport,
-  getCountryCoordinates
 } from './common.js'
 
 export const options = {
@@ -74,52 +67,52 @@ export default function (data) {
   sleep(1)
 }
 
-export function handleSummary(data) {
-    // removing default metrics
-    deleteRoutesMetrics(data)
-    data = routesReport(data)
+export function handleSummary (data) {
+  // removing default metrics
+  deleteRoutesMetrics(data)
+  data = routesReport(data)
 
-    return {
-        stdout: textSummary(data, {
-            indent: ' ',
-            enableColors: true
-        })
-    }
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
-function generateBody(
-    transportation,
-    countryCoords,
-    dateTime
+function generateBody (
+  transportation,
+  countryCoords,
+  dateTime
 ) {
-    const coordinates = countryCoords
-    const diff = 0.01
+  const coordinates = countryCoords
+  const diff = 0.01
 
-    const origin = {
-        id: 'origin',
-        coords: generateRandomCoordinate(coordinates.lat, coordinates.lng, diff)
+  const origin = {
+    id: 'origin',
+    coords: generateRandomCoordinate(coordinates.lat, coordinates.lng, diff)
+  }
+
+  const destination = {
+    id: 'destination',
+    coords: generateRandomCoordinate(coordinates.lat, coordinates.lng, diff)
+  }
+
+  const departureSearches = [{
+    id: 'Routes benchmark',
+    departure_location_id: origin.id,
+    arrival_location_ids: [destination.id],
+    departure_time: dateTime,
+    properties: [
+      'travel_time', 'distance', 'route'
+    ],
+    transportation: {
+      type: transportation
     }
+  }]
 
-    const destination = {
-        id: 'destination',
-        coords: generateRandomCoordinate(coordinates.lat, coordinates.lng, diff)
-    }
-
-    const departureSearches = [{
-        id: 'Routes benchmark',
-        departure_location_id: origin.id,
-        arrival_location_ids: [destination.id],
-        departure_time: dateTime,
-        properties: [
-            'travel_time', 'distance', 'route'
-        ],
-        transportation: {
-            type: transportation
-        }
-    }]
-
-    return JSON.stringify({
-        locations: [origin, destination],
-        departure_searches: departureSearches
-    })
+  return JSON.stringify({
+    locations: [origin, destination],
+    departure_searches: departureSearches
+  })
 }

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -1,3 +1,6 @@
+import {
+  textSummary
+} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -9,9 +12,10 @@ import {
   oneScenario as scenarios,
   setThresholdsForScenarios,
   summaryTrendStats,
+  deleteOneScenarioMetrics,
+  oneScenarioReport,
   getCountryCoordinates,
   generateRequestBodies,
-  handleSummaryInternal,
   randomIndex
 } from './common.js'
 
@@ -62,7 +66,17 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  handleSummaryInternal(data)
+  // removing default metrics
+  deleteOneScenarioMetrics(data)
+
+  data = oneScenarioReport(data)
+
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
 function generateBody (

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -62,10 +62,10 @@ export default function (data) {
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
   if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
-  check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response body is not empty': (r) => r.body.length > 0
-  })
+    check(response, {
+      'status is 200': (r) => r.status === 200,
+      'response body is not empty': (r) => r.body.length > 0
+    })
   }
 }
 

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -4,7 +4,6 @@ import {
 import http from 'k6/http'
 import {
   check,
-  sleep,
   randomSeed
 } from 'k6'
 import {
@@ -15,7 +14,9 @@ import {
   deleteOneScenarioMetrics,
   oneScenarioReport,
   getCountryCoordinates,
-  randomIndex
+  randomIndex,
+  rpm,
+  durationInMinutes
 } from './common.js'
 
 export const options = {
@@ -38,7 +39,9 @@ export function setup () {
   const countryCoords = getCountryCoordinates(countryCode, __ENV.COORDINATES)
   const url = `https://${host}/v4/routes`
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
-  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsPercentage = parseInt(__ENV.UNIQUE_REQUESTS || 2)
+  const uniqueRequestsAmount = Math.ceil((rpm * durationInMinutes) * (uniqueRequestsPercentage / 100))
+
   const dateTime = new Date().toISOString()
 
   const params = {
@@ -61,7 +64,6 @@ export default function (data) {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
-  sleep(1)
 }
 
 export function handleSummary (data) {

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -38,7 +38,7 @@ export function setup () {
   const countryCoords = getCountryCoordinates(countryCode, __ENV.COORDINATES)
   const url = `https://${host}/v4/routes`
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
-  const uniqueRequests = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
   const dateTime = new Date().toISOString()
 
   const params = {
@@ -49,7 +49,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequests, transportation, countryCoords, dateTime)
+  const requestBodies = generateRequestBodies(uniqueRequestsAmount, transportation, countryCoords, dateTime)
   return { url, requestBodies, params }
 }
 

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -28,10 +28,10 @@ export const options = {
   }
 }
 
-export function setup () {
-  setThresholdsForScenarios(options)
-  randomSeed(__ENV.SEED || 1234567)
+setThresholdsForScenarios(options)
+randomSeed(__ENV.SEED || 1234567)
 
+export function setup () {
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
   const host = __ENV.HOST || 'api.traveltimeapp.com'

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -1,3 +1,6 @@
+import {
+  textSummary
+} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import protobuf from 'k6/x/protobuf'
 import {
@@ -10,12 +13,13 @@ import {
   generateDestinations,
   generateRandomCoordinate,
   oneScenario as scenarios,
+  oneScenarioReport,
+  deleteOneScenarioMetrics,
   setThresholdsForScenarios,
   summaryTrendStats,
   getProtoCountryCoordinates,
   randomIndex,
-  generateRequestBodies,
-  handleSummaryInternal
+  generateRequestBodies
 } from './common.js'
 
 export const options = {
@@ -86,7 +90,17 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  handleSummaryInternal(data)
+  // removing default metrics
+  deleteOneScenarioMetrics(data)
+
+  data = oneScenarioReport(data)
+
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
 function transportationType (transportation) {

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -40,7 +40,7 @@ export function setup () {
   const mapDate = __ENV.MAP_DATE || 'unknown'
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
-  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS || 1
+  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS 
   const host = __ENV.HOST || 'proto.api.traveltimeapp.com'
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const protocol = __ENV.PROTOCOL || 'https'
@@ -76,10 +76,6 @@ export default function (data) {
   const response = http.post(data.url, data.encodedRequestBodies[index], data.params)
 
   const decodedResponse = protobuf.load('proto/TimeFilterFastResponse.proto', 'TimeFilterFastResponse').decode(response.body)
-
-  console.log(response.status)
-  console.log(response.body)
-  console.log(decodedResponse)
 
   check(response, {
     'status is 200': (r) => r.status === 200
@@ -130,7 +126,6 @@ function countryCode (country) {
 function encodeBodies (bodies) {
   const proto = protobuf.load('proto/TimeFilterFastRequest.proto', 'TimeFilterFastRequest')
   const encodedBodies = bodies.map(body => proto.encode(body))
-  console.log(encodedBodies[0])
   return encodedBodies
 }
 

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -13,14 +13,10 @@ import {
   setThresholdsForScenarios,
   summaryTrendStats,
   getProtoCountryCoordinates,
-  oneScenarioReport,
-  deleteOneScenarioMetrics,
   randomIndex,
-  generateRequestBodies
+  generateRequestBodies,
+  handleSummaryInternal
 } from './common.js'
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 
 export const options = {
   scenarios,
@@ -90,17 +86,7 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  // removing default metrics
-  deleteOneScenarioMetrics(data)
-
-  data = oneScenarioReport(data)
-
-  return {
-    stdout: textSummary(data, {
-      indent: ' ',
-      enableColors: true
-    })
-  }
+  handleSummaryInternal(data)
 }
 
 function transportationType (transportation) {

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -68,14 +68,14 @@ export function setup () {
 
   const encodedRequestBodyArrays = requestBodyArrays.map(bodies => encodeBodies(bodies))
 
-  return { url, encodedRequestBodyArrays, paramArrays}
+  return { url, encodedRequestBodyArrays, paramArrays }
 }
 
 export default function (data) {
   const destinationsAmount = parseInt(__ENV.SCENARIO_DESTINATIONS)
 
   // We determine which request array we should use
-  const arrayIndex = destinations.findIndex(destination => destination === destinationsAmount);
+  const arrayIndex = destinations.findIndex(destination => destination === destinationsAmount)
   const requests = data.encodedRequestBodyArrays[arrayIndex]
   const params = data.paramArrays[arrayIndex]
 

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -54,15 +54,15 @@ export function setup () {
   const url = `${protocol}://${appId}:${apiKey}@${host}/${query}`
 
   const params = {
-      headers: {
-        'Content-Type': 'application/octet-stream'
-      },
-      tags: {
-        destinations: destinationsAmount,
-        serviceImage,
-        mapDate
-      }
+    headers: {
+      'Content-Type': 'application/octet-stream'
+    },
+    tags: {
+      destinations: destinationsAmount,
+      serviceImage,
+      mapDate
     }
+  }
 
   const requestBodies = generateRequestBodies(uniqueRequestsAmount, generateBody, destinationsAmount, countryCoords, transportation, travelTime, isManyToOne)
 

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -15,7 +15,9 @@ import {
   deleteTimeFilterMetrics,
   summaryTrendStats,
   reportPerDestination,
-  getProtoCountryCoordinates
+  getProtoCountryCoordinates,
+  generateRequestBodies,
+  randomIndex
 } from './common.js'
 import {
   textSummary
@@ -30,15 +32,15 @@ export const options = {
   }
 }
 
-setThresholdsForScenarios(options)
-randomSeed(__ENV.SEED || 1234567)
+export function setup () {
+  setThresholdsForScenarios(options)
+  randomSeed(__ENV.SEED || 1234567)
 
-export default function () {
   const serviceImage = __ENV.SERVICE_IMAGE || 'unknown'
   const mapDate = __ENV.MAP_DATE || 'unknown'
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
-  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS
+  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS || 1
   const host = __ENV.HOST || 'proto.api.traveltimeapp.com'
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const protocol = __ENV.PROTOCOL || 'https'
@@ -48,28 +50,36 @@ export default function () {
   const country = envCountry || 'uk'
   const query = __ENV.QUERY || `api/v2/${countryCode(country)}/time-filter/fast/${transportation}`
   const isManyToOne = __ENV.MANY_TO_ONE !== undefined
+  const uniqueRequests = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const params = {
+    headers: {
+      'Content-Type': 'application/octet-stream'
+    },
+    tags: {
+      destinations: destinationsAmount,
+      serviceImage,
+      mapDate
+    }
+  }
 
   const url = `${protocol}://${appId}:${apiKey}@${host}/${query}`
 
-  const requestBody = protobuf
-    .load('proto/TimeFilterFastRequest.proto', 'TimeFilterFastRequest')
-    .encode(generateBody(destinationsAmount, countryCoords, transportation, travelTime, isManyToOne))
+  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, destinationsAmount, countryCoords, transportation, travelTime, isManyToOne)
 
-  const response = http.post(
-    url,
-    requestBody, {
-      headers: {
-        'Content-Type': 'application/octet-stream'
-      },
-      tags: {
-        destinations: destinationsAmount,
-        serviceImage,
-        mapDate
-      }
-    }
-  )
+  const encodedRequestBodies = encodeBodies(requestBodies)
+
+  return { url, encodedRequestBodies, params }
+}
+
+export default function (data) {
+  const index = randomIndex(data.encodedRequestBodies.length)
+  const response = http.post(data.url, data.encodedRequestBodies[index], data.params)
 
   const decodedResponse = protobuf.load('proto/TimeFilterFastResponse.proto', 'TimeFilterFastResponse').decode(response.body)
+
+  console.log(response.status)
+  console.log(response.body)
+  console.log(decodedResponse)
 
   check(response, {
     'status is 200': (r) => r.status === 200
@@ -115,6 +125,13 @@ function transportationType (transportation) {
 
 function countryCode (country) {
   if (country.startsWith('us_')) { return 'us' } else { return country }
+}
+
+function encodeBodies (bodies) {
+  const proto = protobuf.load('proto/TimeFilterFastRequest.proto', 'TimeFilterFastRequest')
+  const encodedBodies = bodies.map(body => proto.encode(body))
+  console.log(encodedBodies[0])
+  return encodedBodies
 }
 
 function generateBody (destinationsAmount, coord, transportation, travelTime, isManyToOne) {

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -5,7 +5,7 @@ import http from 'k6/http'
 import protobuf from 'k6/x/protobuf'
 import {
   check,
-  randomSeed,
+  randomSeed
 } from 'k6'
 import {
   destinationDeltas,
@@ -71,7 +71,6 @@ export function setup () {
 }
 
 export default function (data) {
-
   const index = randomIndex(data.requestBodies.length)
   const requestBodyEncoded = protobuf
     .load('proto/TimeFilterFastRequest.proto', 'TimeFilterFastRequest')

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -1,6 +1,5 @@
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
+import { getCurrentStageIndex } from 'https://jslib.k6.io/k6-utils/1.3.0/index.js'
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import protobuf from 'k6/x/protobuf'
 import {
@@ -79,13 +78,15 @@ export default function (data) {
 
   const decodedResponse = protobuf.load('proto/TimeFilterFastResponse.proto', 'TimeFilterFastResponse').decode(response.body)
 
-  check(response, {
-    'status is 200': (r) => r.status === 200
-  })
+  if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
+    check(response, {
+      'status is 200': (r) => r.status === 200
+    })
 
-  check(decodedResponse, {
-    'response body is not empty': (r) => r.length !== 0
-  })
+    check(decodedResponse, {
+      'response body is not empty': (r) => r.length !== 0
+    })
+  }
 }
 
 export function handleSummary (data) {

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -18,8 +18,7 @@ import {
   setThresholdsForScenarios,
   summaryTrendStats,
   getProtoCountryCoordinates,
-  randomIndex,
-  generateRequestBodies
+  randomIndex
 } from './common.js'
 
 export const options = {
@@ -64,7 +63,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequestsAmount, generateBody, destinationsAmount, countryCoords, transportation, travelTime, isManyToOne)
+  const requestBodies = generateRequestBodies(uniqueRequestsAmount, destinationsAmount, countryCoords, transportation, travelTime, isManyToOne)
 
   return { url, requestBodies, params }
 }
@@ -149,4 +148,10 @@ function generateBody (destinationsAmount, coord, transportation, travelTime, is
       }
     })
   }
+}
+
+function generateRequestBodies (count, destinationsAmount, coord, transportation, travelTime, isManyToOne) {
+  return Array.from({ length: count }, () => generateBody(
+    destinationsAmount, coord, transportation, travelTime, isManyToOne
+  ))
 }

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -1,6 +1,3 @@
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -13,10 +10,9 @@ import {
   setThresholdsForScenarios,
   summaryTrendStats,
   getCountryCoordinates,
-  deleteOneScenarioMetrics,
-  oneScenarioReport,
   randomIndex,
-  generateRequestBodies
+  generateRequestBodies,
+  handleSummaryInternal
 } from './common.js'
 
 export const options = {
@@ -75,17 +71,7 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  // removing default metrics
-  deleteOneScenarioMetrics(data)
-
-  data = oneScenarioReport(data)
-
-  return {
-    stdout: textSummary(data, {
-      indent: ' ',
-      enableColors: true
-    })
-  }
+  handleSummaryInternal(data)
 }
 
 function generateBody (

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -41,7 +41,7 @@ export function setup () {
   const url = `https://${host}/v4/time-filter`
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 1900)
-  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS || 1
+  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS
   const rangeWidth = __ENV.RANGE || 0
   const rangeSettings = {
     enabled: rangeWidth !== 0,

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -41,7 +41,6 @@ export function setup () {
   const url = `https://${host}/v4/time-filter`
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 1900)
-  const destinationsAmount = __ENV.SCENARIO_DESTINATIONS
   const rangeWidth = __ENV.RANGE || 0
   const rangeSettings = {
     enabled: rangeWidth !== 0,
@@ -60,14 +59,22 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, travelTime, transportation, destinationsAmount, rangeSettings, countryCoords, dateTime)
+  const requestBodyArrays = destinations.map(dest => generateRequestBodies(uniqueRequests, generateBody, travelTime, transportation, dest, rangeSettings, countryCoords, dateTime))
 
-  return { url, requestBodies, params }
+  return { url, requestBodyArrays, params }
 }
 
 export default function (data) {
-  const index = randomIndex(data.requestBodies.length)
-  const response = http.post(data.url, data.requestBodies[index], data.params)
+  const destinationsAmount = parseInt(__ENV.SCENARIO_DESTINATIONS)
+
+  // We determine which request array we should use
+  const arrayIndex = destinations.findIndex(destination => destination === destinationsAmount);
+  const requests = data.requestBodyArrays[arrayIndex]
+
+  const index = randomIndex(requests.length)
+  const response = http.post(data.url, requests[index], data.params)
+
+  console.log(response.status)
 
   check(response, {
     'status is 200': (r) => r.status === 200,

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -1,3 +1,6 @@
+import {
+  textSummary
+} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -8,11 +11,12 @@ import {
   generateRandomCoordinate,
   oneScenario as scenarios,
   setThresholdsForScenarios,
+  oneScenarioReport,
+  deleteOneScenarioMetrics,
   summaryTrendStats,
   getCountryCoordinates,
   randomIndex,
-  generateRequestBodies,
-  handleSummaryInternal
+  generateRequestBodies
 } from './common.js'
 
 export const options = {
@@ -71,7 +75,17 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  handleSummaryInternal(data)
+  // removing default metrics
+  deleteOneScenarioMetrics(data)
+
+  data = oneScenarioReport(data)
+
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
 function generateBody (

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -68,7 +68,7 @@ export default function (data) {
   const destinationsAmount = parseInt(__ENV.SCENARIO_DESTINATIONS)
 
   // We determine which request array we should use
-  const arrayIndex = destinations.findIndex(destination => destination === destinationsAmount);
+  const arrayIndex = destinations.findIndex(destination => destination === destinationsAmount)
   const requests = data.requestBodyArrays[arrayIndex]
 
   const index = randomIndex(requests.length)

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -1,3 +1,4 @@
+import { getCurrentStageIndex } from 'https://jslib.k6.io/k6-utils/1.3.0/index.js'
 import {
   textSummary
 } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
@@ -68,10 +69,12 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
-  check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response body is not empty': (r) => r.body.length > 0
-  })
+  if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
+    check(response, {
+      'status is 200': (r) => r.status === 200,
+      'response body is not empty': (r) => r.body.length > 0
+    })
+  }
 }
 
 export function handleSummary (data) {

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -4,7 +4,6 @@ import {
 import http from 'k6/http'
 import {
   check,
-  sleep,
   randomSeed
 } from 'k6'
 import {
@@ -15,7 +14,9 @@ import {
   deleteOneScenarioMetrics,
   summaryTrendStats,
   getCountryCoordinates,
-  randomIndex
+  randomIndex,
+  rpm,
+  durationInMinutes
 } from './common.js'
 
 export const options = {
@@ -41,7 +42,8 @@ export function setup () {
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 1900)
   const destinationsAmount = parseInt(__ENV.DESTINATIONS || 50)
   const rangeWidth = __ENV.RANGE || 0
-  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsPercentage = parseInt(__ENV.UNIQUE_REQUESTS || 2)
+  const uniqueRequestsAmount = Math.ceil((rpm * durationInMinutes) * (uniqueRequestsPercentage / 100))
   const rangeSettings = {
     enabled: rangeWidth !== 0,
     max_results: 3,
@@ -70,7 +72,6 @@ export default function (data) {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
-  sleep(1)
 }
 
 export function handleSummary (data) {

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -15,8 +15,7 @@ import {
   deleteOneScenarioMetrics,
   summaryTrendStats,
   getCountryCoordinates,
-  randomIndex,
-  generateRequestBodies
+  randomIndex
 } from './common.js'
 
 export const options = {
@@ -58,7 +57,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequestsAmount, generateBody, travelTime, transportation, destinationsAmount, rangeSettings, countryCoords, dateTime)
+  const requestBodies = generateRequestBodies(uniqueRequestsAmount, travelTime, transportation, destinationsAmount, rangeSettings, countryCoords, dateTime)
 
   return { url, requestBodies, params }
 }
@@ -124,4 +123,18 @@ function generateBody (
     locations: destinations,
     departure_searches: departureSearches
   })
+}
+
+function generateRequestBodies (
+  count,
+  travelTime,
+  transportation,
+  destinationsAmount,
+  rangeSettings,
+  countryCoords,
+  dateTime
+) {
+  return Array.from({ length: count }, () => generateBody(
+    travelTime, transportation, destinationsAmount, rangeSettings, countryCoords, dateTime
+  ))
 }

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -1,3 +1,4 @@
+import { getCurrentStageIndex } from 'https://jslib.k6.io/k6-utils/1.3.0/index.js'
 import {
   textSummary
 } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
@@ -61,10 +62,12 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
+  if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
   check(response, {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
+  }
 }
 
 export function handleSummary (data) {

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -63,10 +63,10 @@ export default function (data) {
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
   if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
-  check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response body is not empty': (r) => r.body.length > 0
-  })
+    check(response, {
+      'status is 200': (r) => r.status === 200,
+      'response body is not empty': (r) => r.body.length > 0
+    })
   }
 }
 

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -1,3 +1,6 @@
+import {
+  textSummary
+} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -9,10 +12,11 @@ import {
   summaryTrendStats,
   oneScenario as scenarios,
   setThresholdsForScenarios,
+  oneScenarioReport,
+  deleteOneScenarioMetrics,
   getCountryCoordinates,
   generateRequestBodies,
   randomIndex,
-  handleSummaryInternal
 } from './common.js'
 
 export const options = {
@@ -63,7 +67,17 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  handleSummaryInternal(data)
+  // removing default metrics
+  deleteOneScenarioMetrics(data)
+
+  data = oneScenarioReport(data)
+
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
 function generateBody (travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails) {

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -27,10 +27,11 @@ export const options = {
     // Intentionally empty. I'll define bogus thresholds (to generate the sub-metrics) below.
   }
 }
-setThresholdsForScenarios(options)
-randomSeed(__ENV.SEED || 1234567)
 
 export function setup () {
+  setThresholdsForScenarios(options)
+  randomSeed(__ENV.SEED || 1234567)
+
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
   const host = __ENV.HOST || 'api.traveltimeapp.com'

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -4,7 +4,6 @@ import {
 import http from 'k6/http'
 import {
   check,
-  sleep,
   randomSeed
 } from 'k6'
 import {
@@ -15,7 +14,9 @@ import {
   oneScenarioReport,
   deleteOneScenarioMetrics,
   getCountryCoordinates,
-  randomIndex
+  randomIndex,
+  rpm,
+  durationInMinutes
 } from './common.js'
 
 export const options = {
@@ -41,7 +42,9 @@ export function setup () {
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 7200)
   const levelOfDetails = parseInt(__ENV.LEVEL_OF_DETAILS || -8)
   const arrivalTimePeriod = __ENV.ARRIVAL_TIME_PERIOD || 'weekday_morning'
-  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsPercentage = parseInt(__ENV.UNIQUE_REQUESTS || 2)
+  const uniqueRequestsAmount = Math.ceil((rpm * durationInMinutes) * (uniqueRequestsPercentage / 100))
+
   const params = {
     headers: {
       'Content-Type': 'application/json',
@@ -62,7 +65,6 @@ export default function (data) {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
-  sleep(1)
 }
 
 export function handleSummary (data) {

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -41,7 +41,7 @@ export function setup () {
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 7200)
   const levelOfDetails = parseInt(__ENV.LEVEL_OF_DETAILS || -8)
   const arrivalTimePeriod = __ENV.ARRIVAL_TIME_PERIOD || 'weekday_morning'
-  const uniqueRequests = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
   const params = {
     headers: {
       'Content-Type': 'application/json',
@@ -50,7 +50,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequests, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails)
+  const requestBodies = generateRequestBodies(uniqueRequestsAmount, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails)
   return { url, requestBodies, params }
 }
 

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -14,7 +14,9 @@ import {
   setThresholdsForScenarios,
   deleteOneScenarioMetrics as deleteTimeMapMetrics,
   oneScenarioReport as timeMapReport,
-  getCountryCoordinates
+  getCountryCoordinates,
+  generateRequestBodies,
+  randomIndex
 } from './common.js'
 
 export const options = {
@@ -28,7 +30,7 @@ export const options = {
 setThresholdsForScenarios(options)
 randomSeed(__ENV.SEED || 1234567)
 
-export default function () {
+export function setup () {
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
   const host = __ENV.HOST || 'api.traveltimeapp.com'
@@ -39,6 +41,7 @@ export default function () {
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 7200)
   const levelOfDetails = parseInt(__ENV.LEVEL_OF_DETAILS || -8)
   const arrivalTimePeriod = __ENV.ARRIVAL_TIME_PERIOD || 'weekday_morning'
+  const uniqueRequests = parseInt(__ENV.UNIQUE_REQUESTS || 1)
   const params = {
     headers: {
       'Content-Type': 'application/json',
@@ -47,7 +50,15 @@ export default function () {
     }
   }
 
-  const response = http.post(url, generateBody(travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails), params)
+  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails)
+  return { url, requestBodies, params }
+}
+
+export default function (data) {
+  const index = randomIndex(data.requestBodies.length)
+  const response = http.post(data.url, data.requestBodies[index], data.params)
+
+  console.log(response.status)
 
   check(response, {
     'status is 200': (r) => r.status === 200,

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -15,7 +15,6 @@ import {
   oneScenarioReport,
   deleteOneScenarioMetrics,
   getCountryCoordinates,
-  generateRequestBodies,
   randomIndex
 } from './common.js'
 
@@ -51,7 +50,7 @@ export function setup () {
     }
   }
 
-  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails)
+  const requestBodies = generateRequestBodies(uniqueRequests, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails)
   return { url, requestBodies, params }
 }
 
@@ -101,4 +100,10 @@ function generateBody (travelTime, transportation, countryCoords, arrivalTimePer
       ]
     }
   })
+}
+
+function generateRequestBodies (count, travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails) {
+  return Array.from({ length: count }, () => generateBody(
+    travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails
+  ))
 }

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -1,6 +1,3 @@
-import {
-  textSummary
-} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -12,11 +9,10 @@ import {
   summaryTrendStats,
   oneScenario as scenarios,
   setThresholdsForScenarios,
-  deleteOneScenarioMetrics as deleteTimeMapMetrics,
-  oneScenarioReport as timeMapReport,
   getCountryCoordinates,
   generateRequestBodies,
-  randomIndex
+  randomIndex,
+  handleSummaryInternal
 } from './common.js'
 
 export const options = {
@@ -59,8 +55,6 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
-  console.log(response.status)
-
   check(response, {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
@@ -69,16 +63,7 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  deleteTimeMapMetrics(data)
-
-  data = timeMapReport(data)
-
-  return {
-    stdout: textSummary(data, {
-      indent: ' ',
-      enableColors: true
-    })
-  }
+  handleSummaryInternal(data)
 }
 
 function generateBody (travelTime, transportation, countryCoords, arrivalTimePeriod, levelOfDetails) {

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -28,10 +28,10 @@ export const options = {
   }
 }
 
-export function setup () {
-  setThresholdsForScenarios(options)
-  randomSeed(__ENV.SEED || 1234567)
+setThresholdsForScenarios(options)
+randomSeed(__ENV.SEED || 1234567)
 
+export function setup () {
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
   const host = __ENV.HOST || 'api.traveltimeapp.com'

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -16,7 +16,7 @@ import {
   deleteOneScenarioMetrics,
   getCountryCoordinates,
   generateRequestBodies,
-  randomIndex,
+  randomIndex
 } from './common.js'
 
 export const options = {

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -4,7 +4,6 @@ import {
 import http from 'k6/http'
 import {
   check,
-  sleep,
   randomSeed
 } from 'k6'
 import {
@@ -15,7 +14,9 @@ import {
   oneScenarioReport,
   getCountryCoordinates,
   summaryTrendStats,
-  randomIndex
+  randomIndex,
+  rpm,
+  durationInMinutes
 } from './common.js'
 
 export const options = {
@@ -39,7 +40,8 @@ export function setup () {
   const url = `https://${host}/v4/time-map`
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 7200)
-  const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 1)
+  const uniqueRequestsPercentage = parseInt(__ENV.UNIQUE_REQUESTS || 2)
+  const uniqueRequestsAmount = Math.ceil((rpm * durationInMinutes) * (uniqueRequestsPercentage / 100))
 
   const params = {
     headers: {
@@ -62,7 +64,6 @@ export default function (data) {
     'status is 200': (r) => r.status === 200,
     'response body is not empty': (r) => r.body.length > 0
   })
-  sleep(1)
 }
 
 export function handleSummary (data) {

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -13,7 +13,6 @@ import {
   setThresholdsForScenarios,
   deleteOneScenarioMetrics,
   oneScenarioReport,
-  handleSummaryInternal,
   getCountryCoordinates,
   generateRequestBodies,
   summaryTrendStats,

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -1,3 +1,4 @@
+import { getCurrentStageIndex } from 'https://jslib.k6.io/k6-utils/1.3.0/index.js'
 import {
   textSummary
 } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
@@ -60,10 +61,12 @@ export default function (data) {
   const index = randomIndex(data.requestBodies.length)
   const response = http.post(data.url, data.requestBodies[index], data.params)
 
-  check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response body is not empty': (r) => r.body.length > 0
-  })
+  if (getCurrentStageIndex() === 1) { // Ignoring results from warm-up stage
+    check(response, {
+      'status is 200': (r) => r.status === 200,
+      'response body is not empty': (r) => r.body.length > 0
+    })
+  }
 }
 
 export function handleSummary (data) {

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -1,3 +1,6 @@
+import {
+  textSummary
+} from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import http from 'k6/http'
 import {
   check,
@@ -8,6 +11,8 @@ import {
   generateRandomCoordinate,
   oneScenario as scenarios,
   setThresholdsForScenarios,
+  deleteOneScenarioMetrics,
+  oneScenarioReport,
   handleSummaryInternal,
   getCountryCoordinates,
   generateRequestBodies,
@@ -63,7 +68,17 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
-  handleSummaryInternal(data)
+  // removing default metrics
+  deleteOneScenarioMetrics(data)
+
+  data = oneScenarioReport(data)
+
+  return {
+    stdout: textSummary(data, {
+      indent: ' ',
+      enableColors: true
+    })
+  }
 }
 
 function generateBody (travelTime, transportation, countryCoords, dateTime) {

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -15,6 +15,7 @@ import {
   deleteOneScenarioMetrics as deleteTimeMapMetrics,
   oneScenarioReport as timeMapReport,
   getCountryCoordinates,
+  generateRequestBodies,
   randomIndex
 } from './common.js'
 
@@ -50,7 +51,7 @@ export function setup () {
   }
   const dateTime = new Date().toISOString()
 
-  const requestBodies = generateRequestBodies(uniqueRequests, travelTime, transportation, countryCoords, dateTime)
+  const requestBodies = generateRequestBodies(uniqueRequests, generateBody, travelTime, transportation, countryCoords, dateTime)
   return { url, requestBodies, params }
 }
 
@@ -91,8 +92,4 @@ function generateBody (travelTime, transportation, countryCoords, dateTime) {
       }
     }]
   })
-}
-
-function generateRequestBodies (count, travelTime, transportation, coords, dateTime) {
-  return Array.from({ length: count }, () => generateBody(travelTime, transportation, coords, dateTime))
 }

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -27,11 +27,10 @@ export const options = {
     // Intentionally empty. I'll define bogus thresholds (to generate the sub-metrics) below.
   }
 }
+setThresholdsForScenarios(options)
+randomSeed(__ENV.SEED || 1234567)
 
 export function setup () {
-  setThresholdsForScenarios(options)
-  randomSeed(__ENV.SEED || 1234567)
-
   const appId = __ENV.APP_ID
   const apiKey = __ENV.API_KEY
   const host = __ENV.HOST || 'api.traveltimeapp.com'
@@ -67,6 +66,7 @@ export default function (data) {
 }
 
 export function handleSummary (data) {
+  console.log(data)
   deleteTimeMapMetrics(data)
 
   data = timeMapReport(data)

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -14,7 +14,6 @@ import {
   deleteOneScenarioMetrics,
   oneScenarioReport,
   getCountryCoordinates,
-  generateRequestBodies,
   summaryTrendStats,
   randomIndex
 } from './common.js'
@@ -51,7 +50,7 @@ export function setup () {
   }
   const dateTime = new Date().toISOString()
 
-  const requestBodies = generateRequestBodies(uniqueRequestsAmount, generateBody, travelTime, transportation, countryCoords, dateTime)
+  const requestBodies = generateRequestBodies(uniqueRequestsAmount, travelTime, transportation, countryCoords, dateTime)
   return { url, requestBodies, params }
 }
 
@@ -78,6 +77,10 @@ export function handleSummary (data) {
       enableColors: true
     })
   }
+}
+
+function generateRequestBodies (count, travelTime, transportation, countryCoords, dateTime) {
+  return Array.from({ length: count }, () => generateBody(travelTime, transportation, countryCoords, dateTime))
 }
 
 function generateBody (travelTime, transportation, countryCoords, dateTime) {


### PR DESCRIPTION
Moved as much of the benchmark logic as possible to a `setup` function, which only happens once, source: https://k6.io/docs/using-k6/test-lifecycle/.

Removed the ability to pass in multiple destination values in `time-filter` requests, considerably simplifying a lot of the logic this way.