### PR TITLE
Adding larger setup timeout

### DIFF
--- a/scripts/distance-map.js
+++ b/scripts/distance-map.js
@@ -20,6 +20,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/geocoding-reverse.js
+++ b/scripts/geocoding-reverse.js
@@ -16,6 +16,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/geocoding-search.js
+++ b/scripts/geocoding-search.js
@@ -16,6 +16,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -20,6 +20,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/time-filter-proto.js
+++ b/scripts/time-filter-proto.js
@@ -21,6 +21,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/time-filter.js
+++ b/scripts/time-filter.js
@@ -20,6 +20,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/time-map-fast.js
+++ b/scripts/time-map-fast.js
@@ -20,6 +20,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 

--- a/scripts/time-map.js
+++ b/scripts/time-map.js
@@ -20,6 +20,7 @@ import {
 } from './common.js'
 
 export const options = {
+  setupTimeout: '1000s',
   scenarios,
   summaryTrendStats,
 


### PR DESCRIPTION
With larger `UNIQUE_REQUESTS` values the setup takes longer than 60s and times out.

p.s. I tried (again) to move `options`+`handleSummary` to `common.js`, since they're the same in all scripts, but it always complains about undefined types, I'm not even sure if k6 would allow that. So adding more duplication for now