### PR TITLE
CI: disable persist-credentials for actions/checkout

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         run: |
           docker build -t igeolise/traveltime-k6-benchmarks:${GITHUB_SHA::7} -t igeolise/traveltime-k6-benchmarks:latest .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
It is a possible security issue.
We do not want to persist credentials in the repo and thus exposing those to further steps.

References:

* https://github.com/actions/checkout/issues/485#issuecomment-1197047674
* https://github.com/azat/chdig/pull/67