### PR TITLE
docker tag formatting

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -20,7 +20,7 @@ jobs:
           images: igeolise/traveltime-k6-benchmarks
           tags: |
             type=raw,value=latest
-            type=sha
+            type=sha,prefix=
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Removing default `sha-` prefix before the 7-digit tag 