### PR TITLE
Fix cells-fast.js URL path and geohash-proto.js OOM

### DIFF
--- a/scripts/cells-fast.js
+++ b/scripts/cells-fast.js
@@ -42,7 +42,7 @@ export function setup () {
   const apiKey = __ENV.API_KEY
   const location = __ENV.LOCATION || 'GB/London'
   const locationCoords = getLocationCoordinates(location)
-  const url = __ENV.HOST ? `https://${__ENV.HOST}/v4/${kind}` : __ENV.FULL_URL
+  const url = __ENV.HOST ? `https://${__ENV.HOST}/v4/${kind}/fast` : __ENV.FULL_URL
   const transportation = __ENV.TRANSPORTATION || 'driving+ferry'
   const travelTime = parseInt(__ENV.TRAVEL_TIME || 7200)
   const uniqueRequestsAmount = parseInt(__ENV.UNIQUE_REQUESTS || 100)

--- a/scripts/geohash-proto.js
+++ b/scripts/geohash-proto.js
@@ -66,7 +66,7 @@ export function setup () {
       serviceImage,
       mapDate
     },
-    responseType: 'binary'
+    responseType: disableBodyDecoding ? 'none' : 'binary'
   }
 
   const requestBodies = precomputedDataFile


### PR DESCRIPTION
## Summary

**cells-fast.js** — The URL was constructed as `/v4/${kind}` which routes to the regular service instead of the fast endpoint. Since this script is specifically for benchmarking the fast endpoint, the URL should be `/v4/${kind}/fast`, matching the pattern used by `time-map-fast.js`. With the default `KIND=h3`, every run was silently benchmarking the regular service.

**geohash-proto.js** — The per-request `responseType: 'binary'` overrides the global `discardResponseBodies: true`. Geohash proto responses are ~45MB each, so at high RPM the k6 process OOMs. When `DISABLE_DECODING=true` the response body is never used, so `responseType: 'none'` avoids buffering it entirely.