### PR TITLE
pin xk6 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /app
 
 ENV CGO_ENABLED 0
 RUN apk --no-cache add git=~2
-RUN go install go.k6.io/xk6/cmd/xk6@latest
+# Pin xk6 to v1.3.7 (last release that defaults to k6 v1). xk6 v1.4+ defaults to
+# go.k6.io/k6/v2, which conflicts with extensions still on the v1 module path
+# (xk6-protobuf, xk6-output-prometheus-remote).
+RUN go install go.k6.io/xk6/cmd/xk6@v1.3.7
 
 # Add here all extenstions
 RUN xk6 build \


### PR DESCRIPTION
  - Root cause: xk6@latest (v1.4.3) defaults to k6 v2 (go.k6.io/k6/v2), but xk6-protobuf and
  xk6-output-prometheus-remote still import go.k6.io/k6 v1. xk6 fails at "resolving dependency" with the conflict.
  - Fix: pinned xk6@v1.3.7 in Dockerfile:7 (last release that defaults to k6 v1). One line change + a comment
  explaining why.
  - Tradeoff: pinned until the extensions migrate to k6 v2. When that happens, bump to @latest.
