### PR TITLE
cells-proto: removeWaterBodies support via REMOVE_WATER

### DIFF
--- a/GeohashFastRequest.proto
+++ b/GeohashFastRequest.proto
@@ -12,6 +12,7 @@ message GeohashFastRequest {
     sint32 travelTime = 4;
     uint32 resolution = 5;
     repeated CellPropertyType properties = 6;
+    bool removeWaterBodies = 7;
   }
 
   message ManyToOne {
@@ -21,6 +22,7 @@ message GeohashFastRequest {
     sint32 travelTime = 4;
     uint32 resolution = 5;
     repeated CellPropertyType properties = 6;
+    bool removeWaterBodies = 7;
   }
 
   OneToMany oneToManyRequest = 1;

--- a/scripts/geohash-proto.js
+++ b/scripts/geohash-proto.js
@@ -127,6 +127,8 @@ function generateBody (direction, coord, transportation, travelTime, cellResolut
     resolution: cellResolution,
     properties: ['MEAN']
   }
+  // Field absent from the k6 image's bundled schema; only include (and use the CM-patched proto) when set.
+  if (__ENV.REMOVE_WATER === 'true') commonFields.removeWaterBodies = true
 
   if (direction === 'many-to-one') {
     return JSON.stringify({


### PR DESCRIPTION
 Set `removeWaterBodies` on generated request bodies when `REMOVE_WATER=true`. The field is omitted entirely when unset, so default runs encode byte-identically to before. 